### PR TITLE
refresh connector and converter modules when switching projects

### DIFF
--- a/speckle/host_apps/qgis/qgis_module.py
+++ b/speckle/host_apps/qgis/qgis_module.py
@@ -22,10 +22,13 @@ class SpeckleQGISv3Module:
 
     connector_module: QgisConnectorModule
     converter_module: QgisConverterModule
+    dockwidget: SpeckleQGISv3Dialog
+    iface: Any
 
     def __init__(self, iface):
 
-        self.instantiate_module_dependencies(iface)
+        self.iface = iface
+        self.instantiate_module_dependencies()
 
     def create_dockwidget(self):
         self.dockwidget = SpeckleQGISv3Dialog(
@@ -35,10 +38,10 @@ class SpeckleQGISv3Module:
         self.dockwidget.runSetup()
         self.connect_dockwidget_signals()
 
-    def instantiate_module_dependencies(self, iface):
+    def instantiate_module_dependencies(self):
 
         self.converter_module = QgisConverterModule()
-        self.connector_module = QgisConnectorModule(bridge=self, iface=iface)
+        self.connector_module = QgisConnectorModule(bridge=self, iface=self.iface)
 
         self.connect_connector_module_signals()
         self.connect_converter_module_signals()

--- a/speckle/ui/widgets/dockwidget_main.py
+++ b/speckle/ui/widgets/dockwidget_main.py
@@ -103,6 +103,7 @@ class SpeckleQGISv3Dialog(QDockWidget):
         self._add_start_widget()
 
     def refresh_ui(self):
+        self.bridge.instantiate_module_dependencies()  # should be the first command, before restarting widgets
         self._remove_all_widgets()
         self._add_start_widget()
 


### PR DESCRIPTION
The problem was that the DocumentStore still had the list of Model cards from the previous project, and was picking up those cards first when sending. Now, I refresh the modules when switching projects. 

Remaining issue: the SENT notification stops showing up when switching projects in this PR. 