### PR TITLE
Desktop services auth

### DIFF
--- a/speckle/ui/utils/search_widget_utils.py
+++ b/speckle/ui/utils/search_widget_utils.py
@@ -38,6 +38,8 @@ class UiSearchUtils(QObject):
     new_model_widget_signal = pyqtSignal(str)
     change_account_and_projects_signal = pyqtSignal()
     refresh_models_signal = pyqtSignal()
+    open_add_new_account_widget_signal = pyqtSignal()
+    add_new_account_signal = pyqtSignal()
 
     clear_project_search_bar_signal = pyqtSignal()
     clear_model_search_bar_signal = pyqtSignal()
@@ -55,12 +57,8 @@ class UiSearchUtils(QObject):
         )
         self.batch_size = QUERY_BATCH_SIZE
 
-    def get_accounts_content(self):
+    def get_accounts_content(self) -> List[List[Any]]:
         accounts: List[Account] = get_accounts()
-        if len(accounts) == 0:  # TODO handle no local accounts
-            raise SpeckleException(
-                "Add accounts via Speckle Desktop Manager in order to start"
-            )
 
         content_list = [
             [

--- a/speckle/ui/utils/search_widget_utils.py
+++ b/speckle/ui/utils/search_widget_utils.py
@@ -89,9 +89,10 @@ class UiSearchUtils(QObject):
     def create_new_model(self, project_id: str, model_name: str):
         create_new_model_query(self.speckle_client, project_id, model_name)
 
-    def get_new_projects_content(
-        self, clear_cursor=False, workspace_id: Optional[str] = None
-    ):
+    def get_new_projects_content(self, clear_cursor=False):
+        workspace_id: Optional[str] = (
+            self.current_workspace.id if self.current_workspace else None
+        )
 
         if clear_cursor:
             self.cursor_projects = None
@@ -104,6 +105,13 @@ class UiSearchUtils(QObject):
                 cursor=self.cursor_projects,
             )
         )
+
+        # filter out projects without workspace (if None)
+        if self.current_workspace is None:
+            projects_resource_collection.items = [
+                x for x in projects_resource_collection.items if x.workspace_id is None
+            ]
+
         self.cursor_projects = projects_resource_collection.cursor
         content_list: List[List] = (
             self._create_project_content_list_from_resource_collection(
@@ -113,9 +121,11 @@ class UiSearchUtils(QObject):
 
         return content_list
 
-    def get_new_projects_content_with_name_condition(
-        self, name_filter: str, workspace_id: Optional[str] = None
-    ):
+    def get_new_projects_content_with_name_condition(self, name_filter: str):
+
+        workspace_id: Optional[str] = (
+            self.current_workspace.id if self.current_workspace else None
+        )
 
         self.cursor_projects = None
 
@@ -127,6 +137,13 @@ class UiSearchUtils(QObject):
                 filter_keyword=name_filter,
             )
         )
+
+        # filter out projects without workspace (if None)
+        if self.current_workspace is None:
+            projects_resource_collection.items = [
+                x for x in projects_resource_collection.items if x.workspace_id is None
+            ]
+
         self.cursor_projects = projects_resource_collection.cursor
         content_list: List[List] = (
             self._create_project_content_list_from_resource_collection(

--- a/speckle/ui/widgets/dockwidget_main.py
+++ b/speckle/ui/widgets/dockwidget_main.py
@@ -5,6 +5,7 @@ from speckle.sdk.connectors_common.operations import SendOperationResult
 from speckle.ui.bindings import IBasicConnectorBinding, SelectionInfo
 from speckle.ui.models import ModelCard, SenderModelCard
 from speckle.ui.widgets.widget_account_search import AccountSearchWidget
+from speckle.ui.widgets.widget_add_account import AddAccountWidget
 from speckle.ui.widgets.widget_model_card import ModelCardWidget
 from speckle.ui.widgets.widget_model_cards_list import ModelCardsWidget
 from speckle.ui.widgets.widget_model_search import ModelSearchWidget
@@ -55,6 +56,7 @@ class SpeckleQGISv3Dialog(QDockWidget):
     widget_project_search: ProjectSearchWidget = None
     widget_model_search: ModelSearchWidget = None
     widget_account_search: AccountSearchWidget = None
+    widget_account_add: AddAccountWidget = None
     widget_new_project: NewProjectWidget = None
     widget_new_model: NewModelWidget = None
     widget_model_cards: ModelCardsWidget = None
@@ -221,6 +223,9 @@ class SpeckleQGISv3Dialog(QDockWidget):
         if self.widget_account_search:
             self._remove_widget_account_search()
 
+        if self.widget_account_add:
+            self._remove_widget_account_add()
+
         if self.widget_new_project:
             self._remove_widget_new_project()
 
@@ -269,6 +274,9 @@ class SpeckleQGISv3Dialog(QDockWidget):
         if self.widget_account_search:
             self._remove_widget_account_search()
 
+        if self.widget_account_add:
+            self._remove_widget_account_add()
+
         if self.widget_new_project:
             self._remove_widget_new_project()
 
@@ -286,6 +294,10 @@ class SpeckleQGISv3Dialog(QDockWidget):
     def _remove_widget_account_search(self):
         self.widget_account_search.setParent(None)
         self.widget_account_search = None
+
+    def _remove_widget_account_add(self):
+        self.widget_account_add.setParent(None)
+        self.widget_account_add = None
 
     def _remove_widget_new_project(self):
         self.widget_new_project.setParent(None)
@@ -405,6 +417,16 @@ class SpeckleQGISv3Dialog(QDockWidget):
                 self._update_project_list
             )
 
+    def _update_account_list(self):
+
+        # close AddAccount widget
+        # can be called from AddAccount widget
+        if self.widget_account_add:
+            self._remove_widget_account_add()
+
+        # refresh accounts in the AccountSearch widget
+        self.widget_account_search.refresh_accounts_widget()
+
     def _update_project_list(self):
 
         # can be called from CreateAccount or NewProject widgets
@@ -476,6 +498,29 @@ class SpeckleQGISv3Dialog(QDockWidget):
 
             # subscribe to close-on-background-click event
             self._subscribe_to_close_on_background_click(self.widget_account_search)
+
+            # subscribe to select_account_signal signal
+            self.widget_account_search.ui_search_content.open_add_new_account_widget_signal.connect(
+                self._open_add_account_widget
+            )
+
+            # subscribe to add_new_account_signal signal
+            self.widget_account_search.ui_search_content.add_new_account_signal.connect(
+                self._update_account_list
+            )
+
+    def _open_add_account_widget(self):
+        if not self.widget_account_add:
+            self.widget_account_add = AddAccountWidget(
+                parent=self,
+                ui_search_content=self.widget_project_search.ui_search_content,
+            )
+            # add widgets to the layout
+            self.main_widget.layout.addWidget(self.widget_account_add)
+            self.main_widget.layout.setCurrentWidget(self.widget_account_add)
+
+            # subscribe to close-on-background-click event
+            self._subscribe_to_close_on_background_click(self.widget_account_add)
 
     def _open_select_models_widget(self, project):
 

--- a/speckle/ui/widgets/dockwidget_main.py
+++ b/speckle/ui/widgets/dockwidget_main.py
@@ -438,6 +438,13 @@ class SpeckleQGISv3Dialog(QDockWidget):
         if self.widget_new_project:
             self._remove_widget_new_project()
 
+        # get list of workspaces
+        self.widget_project_search.workspaces = (
+            self.widget_project_search.ui_search_content.get_workspaces()
+        )
+        self.widget_project_search._fill_workspace_dropdown()
+
+        # refresh projects for the selected workspace
         self.widget_project_search.refresh_projects()
 
     def _update_model_list(self):

--- a/speckle/ui/widgets/dockwidget_main.py
+++ b/speckle/ui/widgets/dockwidget_main.py
@@ -428,7 +428,7 @@ class SpeckleQGISv3Dialog(QDockWidget):
             self._remove_widget_account_add()
 
         # refresh accounts in the AccountSearch widget
-        self.widget_account_search.refresh_accounts_widget()
+        self.widget_account_search.refresh_accounts()
 
     def _update_project_list(self):
 

--- a/speckle/ui/widgets/dockwidget_main.py
+++ b/speckle/ui/widgets/dockwidget_main.py
@@ -252,6 +252,9 @@ class SpeckleQGISv3Dialog(QDockWidget):
         elif self.widget_account_search == widget:
             self._remove_widget_account_search()
 
+        elif self.widget_account_add == widget:
+            self._remove_widget_account_add()
+
         elif self.widget_new_project == widget:
             self._remove_widget_new_project()
 

--- a/speckle/ui/widgets/widget_account_search.py
+++ b/speckle/ui/widgets/widget_account_search.py
@@ -56,6 +56,7 @@ class AccountSearchWidget(CardsListTemporaryWidget):
 
         all_accounts = self.ui_search_content.get_accounts_content()
 
+        self._remove_all_cards()
         self._add_more_cards(
             all_accounts, clear_cursor, self.ui_search_content.batch_size
         )

--- a/speckle/ui/widgets/widget_account_search.py
+++ b/speckle/ui/widgets/widget_account_search.py
@@ -25,15 +25,17 @@ class AccountSearchWidget(CardsListTemporaryWidget):
         self.parent = parent
         self.ui_search_content = ui_search_content
 
-        # customize load_more function
-        self._load_more = lambda: self._refresh_accounts(clear_cursor=False)
-
         # initialize the inherited widget, passing the card content
         super(AccountSearchWidget, self).__init__(
-            parent=parent, label_text=label_text, cards_content_list=[]
+            parent=parent,
+            label_text=label_text,
+            cards_content_list=[],
+            init_load_more_btn=False,
         )
+        self.refresh_accounts()
 
-        self.refresh_accounts_widget()
+        button_create = self._create_add_button()
+        self.scroll_container.layout().addWidget(button_create)
 
     def _create_add_button(self) -> QPushButton:
 
@@ -50,7 +52,7 @@ class AccountSearchWidget(CardsListTemporaryWidget):
         )
         return button_create
 
-    def _refresh_accounts(self, clear_cursor=False):
+    def refresh_accounts(self, clear_cursor=False):
 
         all_accounts = self.ui_search_content.get_accounts_content()
 
@@ -60,11 +62,3 @@ class AccountSearchWidget(CardsListTemporaryWidget):
 
         # adjust size of new widget:
         self.resizeEvent()
-
-    def refresh_accounts_widget(self):
-
-        self._refresh_accounts(clear_cursor=True)
-        button_create = self._create_add_button()
-        self.cards_list_layout.addWidget(button_create)
-
-        self.scroll_area.setWidget(self.cards_list_widget)

--- a/speckle/ui/widgets/widget_account_search.py
+++ b/speckle/ui/widgets/widget_account_search.py
@@ -3,6 +3,13 @@ from speckle.ui.widgets.widget_cards_list_temporary import (
     CardsListTemporaryWidget,
 )
 
+from speckle.ui.widgets.utils.global_resources import (
+    BACKGR_COLOR,
+    BACKGR_COLOR_LIGHT,
+)
+
+from PyQt5.QtWidgets import QPushButton
+
 
 class AccountSearchWidget(CardsListTemporaryWidget):
 
@@ -13,22 +20,37 @@ class AccountSearchWidget(CardsListTemporaryWidget):
         *,
         parent=None,
         label_text: str = "Select account",
-        ui_search_content: UiSearchUtils = None
+        ui_search_content: UiSearchUtils = None,
     ):
         self.parent = parent
         self.ui_search_content = ui_search_content
 
         # customize load_more function
-        self._load_more = lambda: self._add_accounts(clear_cursor=False)
+        self._load_more = lambda: self._refresh_accounts(clear_cursor=False)
 
         # initialize the inherited widget, passing the card content
         super(AccountSearchWidget, self).__init__(
             parent=parent, label_text=label_text, cards_content_list=[]
         )
 
-        self._add_accounts(clear_cursor=True)
+        self.refresh_accounts_widget()
 
-    def _add_accounts(self, clear_cursor=False):
+    def _create_add_button(self) -> QPushButton:
+
+        button_create = QPushButton("Add new account")
+        button_create.clicked.connect(
+            self.ui_search_content.open_add_new_account_widget_signal.emit
+        )
+        button_create.setStyleSheet(
+            "QPushButton {"
+            + f"color:white;border-radius: 7px;margin:5px;padding: 5px;height: 20px;text-align: center;{BACKGR_COLOR}"
+            + "} QPushButton:hover { "
+            + f"{BACKGR_COLOR_LIGHT};"
+            + " }"
+        )
+        return button_create
+
+    def _refresh_accounts(self, clear_cursor=False):
 
         all_accounts = self.ui_search_content.get_accounts_content()
 
@@ -38,3 +60,11 @@ class AccountSearchWidget(CardsListTemporaryWidget):
 
         # adjust size of new widget:
         self.resizeEvent()
+
+    def refresh_accounts_widget(self):
+
+        self._refresh_accounts(clear_cursor=True)
+        button_create = self._create_add_button()
+        self.cards_list_layout.addWidget(button_create)
+
+        self.scroll_area.setWidget(self.cards_list_widget)

--- a/speckle/ui/widgets/widget_add_account.py
+++ b/speckle/ui/widgets/widget_add_account.py
@@ -140,7 +140,6 @@ class AddAccountWidget(QWidget):
     def _create_add_button(self) -> QPushButton:
 
         button_create = QPushButton("Create")
-        button_create.clicked.connect(self._add_account_and_exit_widget)
         button_create.setStyleSheet(
             "QPushButton {"
             + f"color:white;border-radius: 7px;margin:5px;padding: 5px;height: 20px;text-align: center;{BACKGR_COLOR}"
@@ -148,9 +147,36 @@ class AddAccountWidget(QWidget):
             + f"{BACKGR_COLOR_LIGHT};"
             + " }"
         )
+        button_create.clicked.connect(self._add_account)
+        button_create.clicked.connect(lambda: self._create_ready_button(button_create))
+
         return button_create
 
-    def _add_account_and_exit_widget(self):
+    def _create_ready_button(self, button):
+
+        try:
+            button.clicked.disconnect(self._add_account)
+            button.clicked.disconnect(self._create_ready_button)
+        except:
+            pass  # ignore if methods already disconnected
+
+        button.setText("READY!")
+        button.clicked.connect(self._exit_widget)
+
+        button.setStyleSheet(
+            "QPushButton {"
+            + f"color:white;border-radius: 7px;margin:5px;padding: 5px;height: 20px;text-align: center;{BACKGR_COLOR}"
+            + "} QPushButton:hover { "
+            + f"{BACKGR_COLOR_LIGHT};"
+            + " }"
+        )
+
+    def _exit_widget(self):
+
+        # the next signal will trigger closing the widget and refreshing project list
+        self.ui_search_content.add_new_account_signal.emit()
+
+    def _add_account(self):
 
         # create a new account, authenticate and write to DB
         server_url: str = self.server_url_widget.text()
@@ -159,9 +185,6 @@ class AddAccountWidget(QWidget):
         api_url = "http://localhost:29364"
         url = f"{api_url}/auth/add-account?serverUrl={server_url}"
         webbrowser.open(url)
-
-        # the next signal will trigger closing the widget and refreshing project list
-        self.ui_search_content.add_new_account_signal.emit()
 
     def resizeEvent(self, event=None):
         QWidget.resizeEvent(self, event)

--- a/speckle/ui/widgets/widget_add_account.py
+++ b/speckle/ui/widgets/widget_add_account.py
@@ -1,0 +1,184 @@
+from speckle.ui.utils.search_widget_utils import UiSearchUtils
+from speckle.ui.widgets.background_widget import BackgroundWidget
+from speckle.ui.widgets.utils.global_resources import (
+    BACKGR_COLOR,
+    BACKGR_COLOR_LIGHT,
+    BACKGR_COLOR_WHITE,
+    WIDGET_SIDE_BUFFER,
+    ZERO_MARGIN_PADDING,
+)
+
+import webbrowser
+
+from PyQt5.QtGui import QColor
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QVBoxLayout,
+    QWidget,
+    QStackedLayout,
+    QPushButton,
+    QLabel,
+    QLineEdit,
+    QGraphicsDropShadowEffect,
+)
+
+
+class AddAccountWidget(QWidget):
+
+    ui_search_content: UiSearchUtils = None
+    _message_card: QWidget = (
+        None  # needs to be here, so it can be called on resize event
+    )
+    server_url_widget: QLineEdit = None
+
+    def __init__(
+        self,
+        *,
+        parent=None,
+        label_text: str = "Add new account",
+        ui_search_content: UiSearchUtils = None,
+    ):
+        super(AddAccountWidget, self).__init__(parent)
+        self.parent = parent
+        self.ui_search_content = ui_search_content
+
+        # align with the parent widget size
+        self.resize(
+            parent.frameSize().width(),
+            parent.frameSize().height(),
+        )
+
+        self._add_background()
+
+        self.layout = QStackedLayout()
+        self.layout.addWidget(self.background)
+
+        self._fill_message_card(label_text)
+
+        content = QWidget()
+        content.layout = QVBoxLayout(self)
+        content.layout.setContentsMargins(0, 0, 0, 0)
+        content.layout.setAlignment(Qt.AlignCenter)
+        content.layout.addWidget(self._message_card)
+
+        self.layout.addWidget(content)
+
+    def _create_widget_label(self, label_text: str, props: str = ""):
+
+        label = QLabel(label_text)
+
+        # for some reason, "margin-left" doesn't make any effect here
+        label.setStyleSheet(
+            "QLabel {"
+            + f"{ZERO_MARGIN_PADDING}padding-left:{int(WIDGET_SIDE_BUFFER/2)};"
+            + f"padding-top:{int(WIDGET_SIDE_BUFFER/4)}; margin-bottom:{int(WIDGET_SIDE_BUFFER/4)};"
+            + f"text-align:left;{props}"
+            + "}"
+        )
+        return label
+
+    def _create_text_widget(self, label_text: str, props: str = ""):
+
+        label = QLabel(label_text)
+
+        # for some reason, "margin-left" doesn't make any effect here
+        label.setStyleSheet(
+            "QLabel {"
+            + f"{ZERO_MARGIN_PADDING}padding-left:5px;padding-right:5px;padding-bottom:5px;"
+            + f"text-align:left;{props}"
+            + "}"
+        )
+        return label
+
+    def _add_background(self):
+        self.background = BackgroundWidget(parent=self, transparent=False)
+        self.background.show()
+
+    def _add_drop_shadow(self, item=None):
+        if not item:
+            item = self
+        # create drop shadow effect
+        self._shadow_effect = QGraphicsDropShadowEffect()
+        self._shadow_effect.setOffset(2, 2)
+        self._shadow_effect.setBlurRadius(8)
+        self._shadow_effect.setColor(QColor.fromRgb(100, 100, 100, 150))
+
+        item.setGraphicsEffect(self._shadow_effect)
+
+    def _fill_message_card(self, label_text: str):
+
+        self._message_card = QWidget()
+        self._message_card.setAttribute(Qt.WA_StyledBackground, True)
+        self._message_card.setStyleSheet(
+            "QWidget {" + "border-radius: 10px;" + f"{BACKGR_COLOR_WHITE}" + "}"
+        )
+        boxLayout = QVBoxLayout(self._message_card)
+
+        label_main = self._create_widget_label(label_text)
+        boxLayout.addWidget(label_main)
+
+        # add text 1
+        label = self._create_text_widget("Server URL:")
+        boxLayout.addWidget(label)
+
+        # add text input 1
+        self.server_url_widget = QLineEdit("https://app.speckle.systems")
+        self.server_url_widget.setMaxLength(40)
+        self.server_url_widget.setStyleSheet(
+            "QLineEdit { "
+            + f"{ZERO_MARGIN_PADDING}margin-left:{int(WIDGET_SIDE_BUFFER/6)};margin-right:{int(WIDGET_SIDE_BUFFER/6)};"
+            + "border: 1px solid lightgrey; height: 30px; border-radius: 5px; "
+            + "}"
+        )
+        boxLayout.addWidget(self.server_url_widget)
+
+        button_create = self._create_add_button()
+        boxLayout.addWidget(button_create)
+
+        self._add_drop_shadow(self._message_card)
+
+    def _create_add_button(self) -> QPushButton:
+
+        button_create = QPushButton("Create")
+        button_create.clicked.connect(self._add_account_and_exit_widget)
+        button_create.setStyleSheet(
+            "QPushButton {"
+            + f"color:white;border-radius: 7px;margin:5px;padding: 5px;height: 20px;text-align: center;{BACKGR_COLOR}"
+            + "} QPushButton:hover { "
+            + f"{BACKGR_COLOR_LIGHT};"
+            + " }"
+        )
+        return button_create
+
+    def _add_account_and_exit_widget(self):
+
+        # create a new account, authenticate and write to DB
+        server_url: str = self.server_url_widget.text()
+
+        # Logic to handle sign in
+        api_url = "http://localhost:29364"
+        url = f"{api_url}/auth/add-account?serverUrl={server_url}"
+        webbrowser.open(url)
+
+        # the next signal will trigger closing the widget and refreshing project list
+        self.ui_search_content.add_new_account_signal.emit()
+
+    def resizeEvent(self, event=None):
+        QWidget.resizeEvent(self, event)
+        try:
+            self.background.resize(
+                self.parent.frameSize().width(),
+                self.parent.frameSize().height(),
+            )
+
+            self._message_card.setGeometry(
+                int(0.5 * WIDGET_SIDE_BUFFER),
+                int(
+                    (self.parent.frameSize().height() - self._message_card.height()) / 2
+                ),
+                self.parent.frameSize().width() - 1 * WIDGET_SIDE_BUFFER,
+                self._message_card.height(),
+            )
+        except RuntimeError as e:
+            # e.g. Widget was deleted
+            pass

--- a/speckle/ui/widgets/widget_cards_list_temporary.py
+++ b/speckle/ui/widgets/widget_cards_list_temporary.py
@@ -17,9 +17,10 @@ from speckle.ui.widgets.widget_card_from_list import CardInListWidget
 class CardsListTemporaryWidget(QWidget):
 
     background: BackgroundWidget = None
-    cards_list_widget: QWidget = None  # needed here to resize child elements
-    load_more_btn: QPushButton = None
     scroll_area: QtWidgets.QScrollArea = None
+    cards_list_widget: QWidget = None  # needed here to resize child elements
+    cards_list_layout: QVBoxLayout = None  # layout to add any widgets below the cards
+    load_more_btn: QPushButton = None
 
     scroll_container: QWidget = None  # overall container, added after the label
 
@@ -114,8 +115,8 @@ class CardsListTemporaryWidget(QWidget):
         self.scroll_area.setAlignment(Qt.AlignHCenter)
 
         # create a widget inside scroll area
-        cards_list_widget = self._create_area_with_cards(cards_content_list)
-        self.scroll_area.setWidget(cards_list_widget)
+        self.cards_list_widget = self._create_area_with_cards(cards_content_list)
+        self.scroll_area.setWidget(self.cards_list_widget)
 
         return self.scroll_area
 
@@ -155,22 +156,20 @@ class CardsListTemporaryWidget(QWidget):
 
     def _create_area_with_cards(self, cards_content_list: List[List]) -> QWidget:
 
-        self.cards_list_widget = QWidget()
-        self.cards_list_widget.setStyleSheet(
-            "QWidget {" + f"{ZERO_MARGIN_PADDING}" + "}"
-        )
-        _ = QVBoxLayout(self.cards_list_widget)
+        cards_list_widget = QWidget()
+        cards_list_widget.setStyleSheet("QWidget {" + f"{ZERO_MARGIN_PADDING}" + "}")
+        self.cards_list_layout = QVBoxLayout(cards_list_widget)
 
         # in case the input argument was missing or None, don't create any cards
         if isinstance(cards_content_list, list):
             for content in cards_content_list:
                 project_card = CardInListWidget(content)
-                self.cards_list_widget.layout().addWidget(project_card)
+                self.cards_list_layout.addWidget(project_card)
 
         self._create_load_more_btn()
-        self.cards_list_widget.layout().addWidget(self.load_more_btn)
+        self.cards_list_layout.addWidget(self.load_more_btn)
 
-        return self.cards_list_widget
+        return cards_list_widget
 
     def _add_more_cards(
         self, new_cards_content_list: list, keep_scroll_on_top=False, batch_size=1
@@ -179,8 +178,8 @@ class CardsListTemporaryWidget(QWidget):
         self.cards_list_widget.setParent(None)
 
         existing_content = []
-        for i in range(self.cards_list_widget.layout().count()):
-            widget = self.cards_list_widget.layout().itemAt(i).widget()
+        for i in range(self.cards_list_layout.count()):
+            widget = self.cards_list_layout.itemAt(i).widget()
             if isinstance(widget, CardInListWidget):
                 existing_content.append(widget.card_content)
 
@@ -188,6 +187,7 @@ class CardsListTemporaryWidget(QWidget):
         assigned_cards_list_widget = self._create_area_with_cards(existing_content)
 
         self.scroll_area.setWidget(assigned_cards_list_widget)
+        self.cards_list_widget = assigned_cards_list_widget
 
         # scroll down
         if not keep_scroll_on_top:

--- a/speckle/ui/widgets/widget_cards_list_temporary.py
+++ b/speckle/ui/widgets/widget_cards_list_temporary.py
@@ -19,7 +19,6 @@ class CardsListTemporaryWidget(QWidget):
     background: BackgroundWidget = None
     scroll_area: QtWidgets.QScrollArea = None
     cards_list_widget: QWidget = None  # needed here to resize child elements
-    cards_list_layout: QVBoxLayout = None  # layout to add any widgets below the cards
     load_more_btn: QPushButton = None
 
     scroll_container: QWidget = None  # overall container, added after the label
@@ -30,9 +29,11 @@ class CardsListTemporaryWidget(QWidget):
         parent=None,
         label_text: str = "Label",
         cards_content_list: List[List],
+        init_load_more_btn: bool = True,
     ):
         super(CardsListTemporaryWidget, self).__init__(parent)
         self.parent: "SpeckleQGISv3Dialog" = parent
+        self.init_load_more_btn = init_load_more_btn
 
         # align with the parent widget size
         self.resize(
@@ -83,7 +84,7 @@ class CardsListTemporaryWidget(QWidget):
 
         return scroll_container
 
-    def _create_container(self):
+    def _create_container(self) -> QWidget:
 
         scroll_container = QWidget()
         scroll_container.setAttribute(QtCore.Qt.WA_StyledBackground, True)
@@ -158,16 +159,17 @@ class CardsListTemporaryWidget(QWidget):
 
         cards_list_widget = QWidget()
         cards_list_widget.setStyleSheet("QWidget {" + f"{ZERO_MARGIN_PADDING}" + "}")
-        self.cards_list_layout = QVBoxLayout(cards_list_widget)
+        _ = QVBoxLayout(cards_list_widget)
 
         # in case the input argument was missing or None, don't create any cards
         if isinstance(cards_content_list, list):
             for content in cards_content_list:
                 project_card = CardInListWidget(content)
-                self.cards_list_layout.addWidget(project_card)
+                cards_list_widget.layout().addWidget(project_card)
 
-        self._create_load_more_btn()
-        self.cards_list_layout.addWidget(self.load_more_btn)
+        if self.init_load_more_btn:
+            self._create_load_more_btn()
+            cards_list_widget.layout().addWidget(self.load_more_btn)
 
         return cards_list_widget
 
@@ -178,8 +180,8 @@ class CardsListTemporaryWidget(QWidget):
         self.cards_list_widget.setParent(None)
 
         existing_content = []
-        for i in range(self.cards_list_layout.count()):
-            widget = self.cards_list_layout.itemAt(i).widget()
+        for i in range(self.cards_list_widget.layout().count()):
+            widget = self.cards_list_widget.layout().itemAt(i).widget()
             if isinstance(widget, CardInListWidget):
                 existing_content.append(widget.card_content)
 
@@ -195,9 +197,8 @@ class CardsListTemporaryWidget(QWidget):
             vbar.setValue(vbar.maximum())
 
         # style LoadMore buttom
-        if len(new_cards_content_list) < batch_size:
+        if self.load_more_btn and len(new_cards_content_list) < batch_size:
             self._style_load_btn(active=False, text="No more items found")
-            return
 
     def _remove_all_cards(self):
         all_count = self.cards_list_widget.layout().count()

--- a/speckle/ui/widgets/widget_project_search.py
+++ b/speckle/ui/widgets/widget_project_search.py
@@ -60,7 +60,6 @@ class ProjectSearchWidget(CardsListTemporaryWidget):
 
     def _add_projects(self, clear_cursor=False, name_filter: Optional[str] = None):
 
-        # get selected workspace
         workspace_id = None  # default to "Personal Projects"
         index = self.workspaces_dropdown.currentIndex()
         if index < len(self.workspaces):
@@ -136,7 +135,10 @@ class ProjectSearchWidget(CardsListTemporaryWidget):
         layout_line.setContentsMargins(10, 0, 0, 0)
 
         # workspaces selection dropdown
-        self.workspaces_dropdown = self._create_workspace_dropdown()
+        self.workspaces_dropdown = QComboBox()
+        self.workspaces_dropdown.currentIndexChanged.connect(self.refresh_projects)
+        self._fill_workspace_dropdown()
+
         layout_line.addWidget(self.workspaces_dropdown)
 
         # Account switch buttom
@@ -145,17 +147,16 @@ class ProjectSearchWidget(CardsListTemporaryWidget):
 
         self.scroll_container.layout().insertWidget(1, line)
 
-    def _create_workspace_dropdown(self):
-        workspaces_dropdown = QComboBox()
-        workspaces_dropdown.addItems([x.name for x in self.workspaces])
-        workspaces_dropdown.addItem("Personal Projects")
-        workspaces_dropdown.setStyleSheet(
+    def _fill_workspace_dropdown(self):
+
+        self.workspaces_dropdown.clear()
+        self.workspaces_dropdown.addItems([x.name for x in self.workspaces])
+        self.workspaces_dropdown.addItem("Personal Projects")
+
+        self.workspaces_dropdown.setStyleSheet(
             """QComboBox { background-color: white; border: 1px solid lightgrey; border-radius: 5px; color: black; height: 30px; padding: 0px 0px 0px 10px; }"""
         )
-        workspaces_dropdown.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-
-        workspaces_dropdown.currentIndexChanged.connect(self.refresh_projects)
-        return workspaces_dropdown
+        self.workspaces_dropdown.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
     def _create_search_widget(self):
         text_box = QLineEdit()

--- a/speckle/ui/widgets/widget_project_search.py
+++ b/speckle/ui/widgets/widget_project_search.py
@@ -65,19 +65,19 @@ class ProjectSearchWidget(CardsListTemporaryWidget):
         if index < len(self.workspaces):
             workspace_id = self.workspaces[index].id
             self.ui_search_content.current_workspace = self.workspaces[index]
-        else:
+        else:  # personal projects
             self.ui_search_content.current_workspace = None
 
         if name_filter is None:
             # just get the projects in batches
             new_project_cards: list = self.ui_search_content.get_new_projects_content(
-                clear_cursor=clear_cursor, workspace_id=workspace_id
+                clear_cursor=clear_cursor
             )
         else:
             # get the projects that match the name condition
             new_project_cards: list = (
                 self.ui_search_content.get_new_projects_content_with_name_condition(
-                    name_filter=name_filter, workspace_id=workspace_id
+                    name_filter=name_filter
                 )
             )
 


### PR DESCRIPTION
Allow to add accounts from the UI, without Manager.
- Added "Add new Account" widget that redirects to browser
- Added "Ready" button for the user to click after they finished logging in via browser. This prevents refreshing account list before user completed authentication
- Choose account and use as usual

![Add_accounts_via_desktop_services_small](https://github.com/user-attachments/assets/047bb549-89fc-442a-8776-68cf658200f4)

